### PR TITLE
Anpassungen nach Rückmeldung BfArM

### DIFF
--- a/src/main/java/de/tk/opensource/services/leistung/diga/DigaFhirVerzeichnisParser.java
+++ b/src/main/java/de/tk/opensource/services/leistung/diga/DigaFhirVerzeichnisParser.java
@@ -167,6 +167,8 @@ public class DigaFhirVerzeichnisParser {
 			for (DigaVerordnungseinheit diga : digas) {
 				readZulassungsZeitraum(catalogEntry, diga);
 				diga.setAppName(display);
+				diga.setAppStatus(catalogEntry.getStatus().name());
+
 				LOG.info(
 					"Added DiGA: "
 					+ diga.getAppName()
@@ -296,7 +298,7 @@ public class DigaFhirVerzeichnisParser {
 		ChargeItemDefinition item = rootDeviceOptional.get();
 
 		diga.setVerordnungseinheitBezeichnung(item.getTitle().trim());
-		diga.setStatus(item.getStatus().name());
+		diga.setVerordnungsEinheitStatus(item.getStatus().name());
 		diga.setPzn(item.getCode().getCodingFirstRep().getCode());
 		diga.setDigaVeId(item.getIdentifierFirstRep().getValue());
 

--- a/src/main/java/de/tk/opensource/services/leistung/diga/type/DigaVerordnungseinheit.java
+++ b/src/main/java/de/tk/opensource/services/leistung/diga/type/DigaVerordnungseinheit.java
@@ -24,7 +24,8 @@ public class DigaVerordnungseinheit {
 	private MetaInfo metaInfo;
 	private String hoechstDauer;
 	private String mindestDauer;
-	private String status;
+	private String appStatus;
+	private String verordnungsEinheitStatus;
 	private Boolean vertragsaerztlicheLeistungen;
 	private NichtErstattungsfaehigeKostenHinweis nichtErstattungsfaehigeKostenHinweis;
 
@@ -198,12 +199,20 @@ public class DigaVerordnungseinheit {
 		this.mindestDauer = mindestDauer;
 	}
 
-	public String getStatus() {
-		return status;
+	public String getAppStatus() {
+		return appStatus;
 	}
 
-	public void setStatus(String status) {
-		this.status = status;
+	public void setAppStatus(String appStatus) {
+		this.appStatus = appStatus;
+	}
+
+	public String getVerordnungsEinheitStatus() {
+		return verordnungsEinheitStatus;
+	}
+
+	public void setVerordnungsEinheitStatus(String verordnungsEinheitStatus) {
+		this.verordnungsEinheitStatus = verordnungsEinheitStatus;
 	}
 
 	public boolean isVertragsaerztlicheLeistungen() {

--- a/src/main/java/de/tk/opensource/services/leistung/diga/type/MetaInfo.java
+++ b/src/main/java/de/tk/opensource/services/leistung/diga/type/MetaInfo.java
@@ -5,7 +5,11 @@ package de.tk.opensource.services.leistung.diga.type;
 public class MetaInfo {
 
 	private String letzteAenderung;
-	private String version;
+	private String organisationVersion;
+	private String appVersion;
+	private String rootDeviceVersion;
+	private String modulVersion;
+	private String verordnungseinheitVersion;
 
 	public String getLetzteAenderung() {
 		return letzteAenderung;
@@ -15,12 +19,57 @@ public class MetaInfo {
 		this.letzteAenderung = letzteAenderung;
 	}
 
-	public String getVersion() {
-		return version;
+	public String getVersionString() {
+		return
+			organisationVersion
+			+ "."
+			+ appVersion
+			+ "."
+			+ rootDeviceVersion
+			+ "."
+			+ modulVersion
+			+ "."
+			+ verordnungseinheitVersion;
 	}
 
-	public void setVersion(String version) {
-		this.version = version;
+	public String getOrganisationVersion() {
+		return organisationVersion;
+	}
+
+	public void setOrganisationVersion(String organisationVersion) {
+		this.organisationVersion = organisationVersion;
+	}
+
+	public String getAppVersion() {
+		return appVersion;
+	}
+
+	public void setAppVersion(String appVersion) {
+		this.appVersion = appVersion;
+	}
+
+	public String getModulVersion() {
+		return modulVersion;
+	}
+
+	public void setModulVersion(String modulVersion) {
+		this.modulVersion = modulVersion;
+	}
+
+	public String getVerordnungseinheitVersion() {
+		return verordnungseinheitVersion;
+	}
+
+	public void setVerordnungseinheitVersion(String verordnungseinheitVersion) {
+		this.verordnungseinheitVersion = verordnungseinheitVersion;
+	}
+
+	public String getRootDeviceVersion() {
+		return rootDeviceVersion;
+	}
+
+	public void setRootDeviceVersion(String rootDeviceVersion) {
+		this.rootDeviceVersion = rootDeviceVersion;
 	}
 
 }


### PR DESCRIPTION
- Unterscheidung in AppStatus und VerordnungseinheitStatus
- Mehrstellige Versionsnummer eingeführt und letztes Änderungsdatum auf "lastUpdated" des letzten geänderten FHIR-Objekts gesetzt (vorher fix lastUpdated der Verordnungseinheit)